### PR TITLE
Fixing karabiner documentation url

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If you're own the CK62 keyboard, this `json` file may help you fix the Layer pro
 * Then you need to copy the `customCK62.json` to the Karabiner directory, using the command below:
   * `$cp customCK62.json ~/.config/karabiner/assets/complex_modifications`
 
-After that, just open `Karabiner` and activate this rule. If you need any assistant on that, please follow this [guide](https://pqrs.org/osx/karabiner/document.html).
+After that, just open `Karabiner` and activate this rule. If you need any assistant on that, please follow this [guide](https://pqrs.org/osx/karabiner/docs/).
 
 ## Author
 


### PR DESCRIPTION
They probably changed the route of the documentation url, so I am proposing to change to actual and working route.